### PR TITLE
Automatically determine scalar types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Usage
 Construct a GraphQL client, specifying the GraphQL server URL. Then, you can use it to make GraphQL queries and mutations.
 
 ```Go
-client := graphql.NewClient("https://example.com/graphql", nil, nil)
+client := graphql.NewClient("https://example.com/graphql", nil)
 // Use client...
 ```
 
@@ -41,7 +41,7 @@ func main() {
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 
-	client := graphql.NewClient("https://example.com/graphql", httpClient, nil)
+	client := graphql.NewClient("https://example.com/graphql", httpClient)
 	// Use client...
 ```
 

--- a/example/graphqldev/main.go
+++ b/example/graphqldev/main.go
@@ -38,7 +38,7 @@ func run() error {
 	mux := http.NewServeMux()
 	mux.Handle("/query", &relay.Handler{Schema: schema})
 
-	client := graphql.NewClient("/query", &http.Client{Transport: localRoundTripper{handler: mux}}, nil)
+	client := graphql.NewClient("/query", &http.Client{Transport: localRoundTripper{handler: mux}})
 
 	/*
 		query {

--- a/graphql.go
+++ b/graphql.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 
 	"github.com/shurcooL/go/ctxhttp"
 	"github.com/shurcooL/graphql/internal/jsonutil"
@@ -16,25 +15,17 @@ import (
 type Client struct {
 	url        string // GraphQL server URL.
 	httpClient *http.Client
-
-	qctx *queryContext
 }
 
 // NewClient creates a GraphQL client targeting the specified GraphQL server URL.
 // If httpClient is nil, then http.DefaultClient is used.
-// scalars optionally specifies types that are scalars (this matters
-// when constructing queries from types, scalars are never expanded).
-func NewClient(url string, httpClient *http.Client, scalars []reflect.Type) *Client {
+func NewClient(url string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	return &Client{
 		url:        url,
 		httpClient: httpClient,
-
-		qctx: &queryContext{
-			Scalars: scalars,
-		},
 	}
 }
 
@@ -57,9 +48,9 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	var query string
 	switch op {
 	case queryOperation:
-		query = constructQuery(c.qctx, v, variables)
+		query = constructQuery(v, variables)
 	case mutationOperation:
-		query = constructMutation(c.qctx, v, variables)
+		query = constructMutation(v, variables)
 	}
 	in := struct {
 		Query     string                 `json:"query"`


### PR DESCRIPTION
Previously, I didn't know of a good way to determine scalar types automatically, so the interim solution was to require the user to specify the scalar types explicitly.

This has the downside that it makes it not possible to substitute GraphQL-specific types with equivalent other types when unmarshaling results of a query. E.g., one would have to always use `githubql.DateTime` and couldn't use the standard `time.Time`.

I've now discovered a way to determine scalar types automatically: they are structs that implement `json.Unmarshaler` interface.

This commit implements the change to automatic scalar type detection, and removes the no longer necessary explicit passing of scalars.