### PR TITLE
Add ability to set operation names on Query/Mutate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ fmt.Println(query.Me.Name)
 // Output: Luke Skywalker
 ```
 
+### Operation Names
+
+To create [named queries](http://graphql.org/learn/queries/#operation-name), use the variants `client.QueryByName` and `client.MutateByName`.
+
 ### Arguments and Variables
 
 Often, you'll want to specify arguments on some fields. You can use the `graphql` struct field tag for this.

--- a/graphql.go
+++ b/graphql.go
@@ -29,28 +29,45 @@ func NewClient(url string, httpClient *http.Client) *Client {
 	}
 }
 
+// Empty operation name for anonymous queries
+var noOpName = ""
+
 // Query executes a single GraphQL query request,
 // with a query derived from q, populating the response into it.
 // q should be a pointer to struct that corresponds to the GraphQL schema.
 func (c *Client) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
-	return c.do(ctx, queryOperation, q, variables)
+	return c.do(ctx, queryOperation, noOpName, q, variables)
+}
+
+// QueryByName executes a single GraphQL query request with the given `operationName`,
+// with a query derived from q, populating the response into it.
+// q should be a pointer to struct that corresponds to the GraphQL schema.
+func (c *Client) QueryByName(ctx context.Context, operationName string, q interface{}, variables map[string]interface{}) error {
+	return c.do(ctx, queryOperation, operationName, q, variables)
 }
 
 // Mutate executes a single GraphQL mutation request,
 // with a mutation derived from m, populating the response into it.
 // m should be a pointer to struct that corresponds to the GraphQL schema.
 func (c *Client) Mutate(ctx context.Context, m interface{}, variables map[string]interface{}) error {
-	return c.do(ctx, mutationOperation, m, variables)
+	return c.do(ctx, mutationOperation, noOpName, m, variables)
+}
+
+// MutateByName executes a single GraphQL mutation request with the given `operationName`,
+// with a mutation derived from m, populating the response into it.
+// m should be a pointer to struct that corresponds to the GraphQL schema.
+func (c *Client) MutateByName(ctx context.Context, operationName string, m interface{}, variables map[string]interface{}) error {
+	return c.do(ctx, mutationOperation, operationName, m, variables)
 }
 
 // do executes a single GraphQL operation.
-func (c *Client) do(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}) error {
+func (c *Client) do(ctx context.Context, op operationType, opName string, v interface{}, variables map[string]interface{}) error {
 	var query string
 	switch op {
 	case queryOperation:
-		query = constructQuery(v, variables)
+		query = constructQuery(v, opName, variables)
 	case mutationOperation:
-		query = constructMutation(v, variables)
+		query = constructMutation(v, opName, variables)
 	}
 	in := struct {
 		Query     string                 `json:"query"`

--- a/query.go
+++ b/query.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
@@ -10,20 +11,38 @@ import (
 	"github.com/shurcooL/graphql/ident"
 )
 
-func constructQuery(v interface{}, variables map[string]interface{}) string {
+func constructQuery(v interface{}, opName string, variables map[string]interface{}) string {
 	query := query(v)
 	if variables != nil {
-		return "query(" + queryArguments(variables) + ")" + query
+		if opName == noOpName {
+			return fmt.Sprintf("query(%s)%s", queryArguments(variables), query)
+		}
+
+		return fmt.Sprintf("query %s(%s)%s", opName, queryArguments(variables), query)
 	}
-	return query
+
+	if opName == noOpName {
+		return query
+	}
+
+	return "query " + opName + query
 }
 
-func constructMutation(v interface{}, variables map[string]interface{}) string {
+func constructMutation(v interface{}, opName string, variables map[string]interface{}) string {
 	query := query(v)
 	if variables != nil {
-		return "mutation(" + queryArguments(variables) + ")" + query
+		if opName == noOpName {
+			return fmt.Sprintf("mutation(%s)%s", queryArguments(variables), query)
+		}
+
+		return fmt.Sprintf("mutation %s(%s)%s", opName, queryArguments(variables), query)
 	}
-	return "mutation" + query
+
+	if opName == noOpName {
+		return "mutation" + query
+	}
+
+	return "mutation " + opName + query
 }
 
 // queryArguments constructs a minified arguments string for variables.


### PR DESCRIPTION
AFAIK, there is currently no way to add an [Operation Name](http://graphql.org/learn/queries/#operation-name) to queries.

Added two api methods: `client.QueryByName` and `client.MutateByName`
which take an `operationName` argument that gets passed onto the created
query string.

This is a backward compatible change, although you could argue that operation name should be a first class citizen on the `Query`/`Mutate` methods, but that would break existing clients.

Fixes #12.