### PR TITLE
Detect recursive structures when generating queries

### DIFF
--- a/query.go
+++ b/query.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
@@ -88,16 +89,23 @@ func writeArgumentType(w io.Writer, t reflect.Type, value bool) {
 // E.g., struct{Foo Int, BarBaz *Boolean} -> "{foo,barBaz}".
 func query(v interface{}) string {
 	var buf bytes.Buffer
-	writeQuery(&buf, reflect.TypeOf(v), false)
+	writeQuery(&buf, reflect.TypeOf(v), map[edge]int{}, false)
 	return buf.String()
+}
+
+// edge is simply a tuple to key the visitation map that we use to keep
+// writeQuery from recursing without bound on recursive types.
+type edge struct {
+	t  reflect.Type
+	fn int
 }
 
 // writeQuery writes a minified query for t to w.
 // If inline is true, the struct fields of t are inlined into parent struct.
-func writeQuery(w io.Writer, t reflect.Type, inline bool) {
+func writeQuery(w io.Writer, t reflect.Type, visited map[edge]int, inline bool) {
 	switch t.Kind() {
 	case reflect.Ptr, reflect.Slice:
-		writeQuery(w, t.Elem(), false)
+		writeQuery(w, t.Elem(), visited, false)
 	case reflect.Struct:
 		// If the type implements json.Unmarshaler, it's a scalar. Don't expand it.
 		if reflect.PtrTo(t).Implements(jsonUnmarshaler) {
@@ -111,6 +119,14 @@ func writeQuery(w io.Writer, t reflect.Type, inline bool) {
 				io.WriteString(w, ",")
 			}
 			f := t.Field(i)
+
+			// Check how many times we've traversed this before (recursion limit).
+			edge := edge{t, i}
+			visited[edge]++
+			if visited[edge] > 1 {
+				panic(fmt.Errorf("cycle found"))
+			}
+
 			value, ok := f.Tag.Lookup("graphql")
 			inlineField := f.Anonymous && !ok
 			if !inlineField {
@@ -120,7 +136,8 @@ func writeQuery(w io.Writer, t reflect.Type, inline bool) {
 					io.WriteString(w, ident.ParseMixedCaps(f.Name).ToLowerCamelCase())
 				}
 			}
-			writeQuery(w, f.Type, inlineField)
+			writeQuery(w, f.Type, visited, inlineField)
+			visited[edge]--
 		}
 		if !inline {
 			io.WriteString(w, "}")


### PR DESCRIPTION
This is a fix for #17 .  It adds a cycle detector to the query generator, as well as a stack for remembering the path so we can produce good error messages in case of detecting a cycle.

New tests for cyclic structures are added, and showcase the error messages for cycles.  (I'm pretty open to suggestions on that format, though.  This is just the first thing that came to mind which produces relatively minimal amounts of output while also never producing empty strings (anonymous types can be a bit tricky to refer to).)

Use of an `int` in the cycle detection map rather than using a set with empty placeholder `struct{}` values is overkill, but a choice made with https://github.com/shurcooL/graphql/issues/9 in mind -- you can see how just a few changes around the `visited[edge] > 1` line can add a lot of power.