### PR TITLE
Unmarshal data field only if present.

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -73,7 +73,7 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 		return fmt.Errorf("unexpected status: %v", resp.Status)
 	}
 	var out struct {
-		Data   json.RawMessage
+		Data   *json.RawMessage
 		Errors errors
 		//Extensions interface{} // Unused.
 	}
@@ -81,9 +81,11 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	if err != nil {
 		return err
 	}
-	err = jsonutil.UnmarshalGraphQL(out.Data, v)
-	if err != nil {
-		return err
+	if out.Data != nil {
+		err := jsonutil.UnmarshalGraphQL(*out.Data, v)
+		if err != nil {
+			return err
+		}
 	}
 	if len(out.Errors) > 0 {
 		return out.Errors


### PR DESCRIPTION
The data field may not be present in the response from GraphQL server.
This is valid according to GraphQL specification, section 7.2.1
(https://facebook.github.io/graphql/October2016/#sec-Data):

>	If an error was encountered before execution begins, the `data` entry
>	should not be present in the result.

If it's not present, it won't have a valid JSON value. As a result,
`jsonutil.UnmarshalGraphQL` will return an "unexpected end of JSON input"
error, and prevent errors from the GraphQL response from being returned.
We don't want that, so only try to Unmarshal the data value if it's
present in the response.

Fixes #22.