### PR TITLE
Provide ConstructQuery and ConstructMutation to public interface

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -48,9 +48,9 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	var query string
 	switch op {
 	case queryOperation:
-		query = constructQuery(v, variables)
+		query = ConstructQuery(v, variables)
 	case mutationOperation:
-		query = constructMutation(v, variables)
+		query = ConstructMutation(v, variables)
 	}
 	in := struct {
 		Query     string                 `json:"query"`

--- a/query.go
+++ b/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/shurcooL/graphql/ident"
 )
 
-func constructQuery(v interface{}, variables map[string]interface{}) string {
+func ConstructQuery(v interface{}, variables map[string]interface{}) string {
 	query := query(v)
 	if variables != nil {
 		return "query(" + queryArguments(variables) + ")" + query
@@ -18,7 +18,7 @@ func constructQuery(v interface{}, variables map[string]interface{}) string {
 	return query
 }
 
-func constructMutation(v interface{}, variables map[string]interface{}) string {
+func ConstructMutation(v interface{}, variables map[string]interface{}) string {
 	query := query(v)
 	if variables != nil {
 		return "mutation(" + queryArguments(variables) + ")" + query

--- a/query_test.go
+++ b/query_test.go
@@ -229,7 +229,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := constructQuery(tc.inV, tc.inVariables)
+		got := ConstructQuery(tc.inV, tc.inVariables)
 		if got != tc.want {
 			t.Errorf("\ngot:  %q\nwant: %q\n", got, tc.want)
 		}
@@ -264,7 +264,7 @@ func TestConstructMutation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := constructMutation(tc.inV, tc.inVariables)
+		got := ConstructMutation(tc.inV, tc.inVariables)
 		if got != tc.want {
 			t.Errorf("\ngot:  %q\nwant: %q\n", got, tc.want)
 		}


### PR DESCRIPTION
I need this feature to write logs with full request data. 

It's easy and beautiful to use your methods as library public interface. 