### PR TITLE
Fix not to panic when struct contains an unexported field

### DIFF
--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -304,5 +304,8 @@ func unmarshalValue(value json.Token, v reflect.Value) error {
 	if !v.CanAddr() {
 		return fmt.Errorf("value %v is not addressable", v)
 	}
+	if !v.CanInterface() {
+		return errors.New("struct contains an unexported field")
+	}
 	return json.Unmarshal(b, v.Addr().Interface())
 }

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -102,7 +102,7 @@ func (d *decoder) decode() error {
 				d.vs[i] = append(d.vs[i], f)
 			}
 			if !someFieldExist {
-				return fmt.Errorf("struct field for %s doesn't exist in any of %v places to unmarshal", key, len(d.vs))
+				return fmt.Errorf("struct field for %q doesn't exist in any of %v places to unmarshal", key, len(d.vs))
 			}
 
 			// We've just consumed the current token, which was the key.
@@ -252,10 +252,14 @@ func (d *decoder) popAllVs() {
 	d.vs = nonEmpty
 }
 
-// fieldByGraphQLName returns a struct field of struct v that matches GraphQL name,
-// or invalid reflect.Value if none found.
+// fieldByGraphQLName returns an exported struct field of struct v
+// that matches GraphQL name, or invalid reflect.Value if none found.
 func fieldByGraphQLName(v reflect.Value, name string) reflect.Value {
 	for i := 0; i < v.NumField(); i++ {
+		if v.Type().Field(i).PkgPath != "" {
+			// Skip unexported field.
+			continue
+		}
 		if hasGraphQLName(v.Type().Field(i), name) {
 			return v.Field(i)
 		}
@@ -296,16 +300,12 @@ func isGraphQLFragment(f reflect.StructField) bool {
 }
 
 // unmarshalValue unmarshals JSON value into v.
+// v must be addressable and not obtained by the use of unexported
+// struct fields, otherwise unmarshalValue will panic.
 func unmarshalValue(value json.Token, v reflect.Value) error {
 	b, err := json.Marshal(value) // TODO: Short-circuit (if profiling says it's worth it).
 	if err != nil {
 		return err
-	}
-	if !v.CanAddr() {
-		return fmt.Errorf("value %v is not addressable", v)
-	}
-	if !v.CanInterface() {
-		return errors.New("struct contains an unexported field")
 	}
 	return json.Unmarshal(b, v.Addr().Interface())
 }

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -241,6 +241,19 @@ func TestUnmarshalGraphQL_pointerWithInlineFragment(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_unexportedField(t *testing.T) {
+	type query struct {
+		foo graphql.String
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{"foo": "bar"}`), new(query))
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if got, want := err.Error(), "struct field for \"foo\" doesn't exist in any of 1 places to unmarshal"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+}
+
 func TestUnmarshalGraphQL_multipleValues(t *testing.T) {
 	type query struct {
 		Foo graphql.String
@@ -378,18 +391,5 @@ func TestUnmarshalGraphQL_arrayInsideInlineFragment(t *testing.T) {
 	want.Search.Nodes[0].PullRequest.Commits.Nodes[0].URL = "https://example.org/commit/49e1"
 	if !reflect.DeepEqual(got, want) {
 		t.Error("not equal")
-	}
-}
-
-func TestUnmarshalGraphQL_unexportedField(t *testing.T) {
-	type query struct {
-		foo graphql.String
-	}
-	err := jsonutil.UnmarshalGraphQL([]byte(`{"foo": "bar"}{"foo": "baz"}`), new(query))
-	if err == nil {
-		t.Fatal("got error: nil, want: non-nil")
-	}
-	if got, want := err.Error(), "struct contains an unexported field"; got != want {
-		t.Errorf("got error: %v, want: %v", got, want)
 	}
 }

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -380,3 +380,16 @@ func TestUnmarshalGraphQL_arrayInsideInlineFragment(t *testing.T) {
 		t.Error("not equal")
 	}
 }
+
+func TestUnmarshalGraphQL_unexportedField(t *testing.T) {
+	type query struct {
+		foo graphql.String
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{"foo": "bar"}{"foo": "baz"}`), new(query))
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if got, want := err.Error(), "struct contains an unexported field"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Thank you so much for a wonderful library!

I encountered the same problem with https://github.com/shurcooL/githubv4/issues/37, so I fixed it not to panic and return an error instead. As you mentioned in the issue, I think it would be better for the library to return error rather ignoring the panic, since that makes it easier for users to debug!

Thanks 👍 
