### PR TITLE
Changes to support raw json fields

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2,6 +2,7 @@ package graphql_test
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -61,6 +62,55 @@ func TestClient_Query_partialDataWithErrorResponse(t *testing.T) {
 	}
 	if q.Node2 != nil {
 		t.Errorf("got non-nil q.Node2: %v, want: nil", *q.Node2)
+	}
+}
+
+func TestClient_Query_partialDataRawQueryWithErrorResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(w, `{
+			"data": {
+				"node1": { "id": "MDEyOklzc3VlQ29tbWVudDE2OTQwNzk0Ng==" },
+				"node2": null
+			},
+			"errors": [
+				{
+					"message": "Could not resolve to a node with the global id of 'NotExist'",
+					"type": "NOT_FOUND",
+					"path": [
+						"node2"
+					],
+					"locations": [
+						{
+							"line": 10,
+							"column": 4
+						}
+					]
+				}
+			]
+		}`)
+	})
+	client := graphql.NewClient("/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
+
+	var q struct {
+		Node1 json.RawMessage `graphql:"node1"`
+		Node2 *struct {
+			ID graphql.ID
+		} `graphql:"node2: node(id: \"NotExist\")"`
+	}
+	err := client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil\n")
+	}
+	if got, want := err.Error(), "Could not resolve to a node with the global id of 'NotExist'"; got != want {
+		t.Errorf("got error: %v, want: %v\n", got, want)
+	}
+	if q.Node1 == nil || string(q.Node1) != `{"id":"MDEyOklzc3VlQ29tbWVudDE2OTQwNzk0Ng=="}` {
+		t.Errorf("got wrong q.Node1: %v\n", string(q.Node1))
+	}
+	if q.Node2 != nil {
+		t.Errorf("got non-nil q.Node2: %v, want: nil\n", *q.Node2)
 	}
 }
 

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -1,6 +1,7 @@
 package jsonutil_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -77,6 +78,29 @@ func TestUnmarshalGraphQL_jsonTag(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Error("not equal")
+	}
+}
+
+func TestUnmarshalGraphQL_jsonRawTag(t *testing.T) {
+	type query struct {
+		Data    json.RawMessage
+		Another string
+	}
+	var got query
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"Data": { "foo":"bar" },
+		"Another" : "stuff"
+        }`), &got)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		Another: "stuff",
+		Data:    []byte(`{"foo":"bar"}`),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("not equal: %v %v", want, got)
 	}
 }
 


### PR DESCRIPTION
By specifing json.RawMessage as a field type in a query raw
json fields can be queried and returned.

This would address #32