### PR TITLE
Add variadic RequestOption to Query and Mutate

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -30,22 +30,33 @@ func NewClient(url string, httpClient *http.Client) *Client {
 	}
 }
 
+// RequestOption is a variadic option for modifying an underlying HTTP request
+// for GraphQL.
+type RequestOption func(req *http.Request)
+
+// WithRequestHeader sets an explicit HTTP header for usage
+func WithRequestHeader(key, value string) RequestOption {
+	return func(req *http.Request) {
+		req.Header.Set(key, value)
+	}
+}
+
 // Query executes a single GraphQL query request,
 // with a query derived from q, populating the response into it.
 // q should be a pointer to struct that corresponds to the GraphQL schema.
-func (c *Client) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
-	return c.do(ctx, queryOperation, q, variables)
+func (c *Client) Query(ctx context.Context, q interface{}, variables map[string]interface{}, opts ...RequestOption) error {
+	return c.do(ctx, queryOperation, q, variables, opts...)
 }
 
 // Mutate executes a single GraphQL mutation request,
 // with a mutation derived from m, populating the response into it.
 // m should be a pointer to struct that corresponds to the GraphQL schema.
-func (c *Client) Mutate(ctx context.Context, m interface{}, variables map[string]interface{}) error {
-	return c.do(ctx, mutationOperation, m, variables)
+func (c *Client) Mutate(ctx context.Context, m interface{}, variables map[string]interface{}, opts ...RequestOption) error {
+	return c.do(ctx, mutationOperation, m, variables, opts...)
 }
 
 // do executes a single GraphQL operation.
-func (c *Client) do(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}) error {
+func (c *Client) do(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, opts ...RequestOption) error {
 	var query string
 	switch op {
 	case queryOperation:
@@ -65,7 +76,17 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	if err != nil {
 		return err
 	}
-	resp, err := ctxhttp.Post(ctx, c.httpClient, c.url, "application/json", &buf)
+	req, err := http.NewRequest(http.MethodPost, c.url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp, err := ctxhttp.Do(ctx, c.httpClient, req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/shurcooL/graphql/issues/28.

I saw various solutions in https://github.com/shurcooL/graphql/issues/28, especially this one: https://github.com/shurcooL/graphql/issues/28#issuecomment-485226864. I decided to take the variadic options approach because: 

1) It's backwards compatible
2) Easy to build on top of and set other nice options that users may want to use. 

I've gone ahead and included a `WithRequestHeader` option that users will most likely want.