### PR TITLE
Allow providing a custom request factory

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -16,6 +16,16 @@ import (
 type Client struct {
 	url        string // GraphQL server URL.
 	httpClient *http.Client
+	RequestFactory func(method, url string, body io.Reader) (*http.Request, error)
+}
+
+// defaultRequestFactory creates JSON requests
+func defaultRequestFactory(method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err == nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, err
 }
 
 // NewClient creates a GraphQL client targeting the specified GraphQL server URL.
@@ -27,6 +37,7 @@ func NewClient(url string, httpClient *http.Client) *Client {
 	return &Client{
 		url:        url,
 		httpClient: httpClient,
+		RequestFactory: defaultRequestFactory,
 	}
 }
 
@@ -65,7 +76,11 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	if err != nil {
 		return err
 	}
-	resp, err := ctxhttp.Post(ctx, c.httpClient, c.url, "application/json", &buf)
+	req, err := c.RequestFactory(http.MethodPost, c.url, &buf)
+	if err != nil {
+		return err
+	}
+	resp, err := ctxhttp.Do(ctx, c.httpClient, req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR allows customizing the requests sent for APIs that require additional headers.

Replace #47, #48, #49, https://github.com/shurcooL/graphql/pull/64, #68. 

This is not the most beautiful solution but offers the highest amount of customizing the request with the least amount of added lines of code. Making the request factory a private member and optional `NewClient` parameter would be a further option.

/cc @dmitshur 