### PR TITLE
Add directive support

### DIFF
--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -280,6 +280,9 @@ func hasGraphQLName(f reflect.StructField, name string) bool {
 		// GraphQL fragment. It doesn't have a name.
 		return false
 	}
+	if i := strings.Index(value, "@"); i != -1 {
+		value = value[:i]
+	}
 	if i := strings.Index(value, "("); i != -1 {
 		value = value[:i]
 	}

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -280,13 +280,9 @@ func hasGraphQLName(f reflect.StructField, name string) bool {
 		// GraphQL fragment. It doesn't have a name.
 		return false
 	}
-	if i := strings.Index(value, "@"); i != -1 {
-		value = value[:i]
-	}
-	if i := strings.Index(value, "("); i != -1 {
-		value = value[:i]
-	}
-	if i := strings.Index(value, ":"); i != -1 {
+	// Cut off anything that follows the field name,
+	// such as field arguments, aliases, directives.
+	if i := strings.IndexAny(value, "(:@"); i != -1 {
 		value = value[:i]
 	}
 	return strings.TrimSpace(value) == name

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -267,6 +267,39 @@ func TestUnmarshalGraphQL_multipleValues(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_directives(t *testing.T) {
+	/*
+		query {
+			me {
+				name @include(if: true)
+				height @skip(if: false)
+			}
+		}
+	*/
+	type query struct {
+		Me struct {
+			Name   graphql.String `graphql:"name @include(if: true)"`
+			Height graphql.Float  `graphql:"height @skip(if: false)"`
+		}
+	}
+	var got query
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"me": {
+			"name": "Luke Skywalker",
+			"height": 1.72
+		}
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want query
+	want.Me.Name = "Luke Skywalker"
+	want.Me.Height = 1.72
+	if !reflect.DeepEqual(got, want) {
+		t.Error("not equal")
+	}
+}
+
 func TestUnmarshalGraphQL_union(t *testing.T) {
 	/*
 		{


### PR DESCRIPTION
Situations where only a directive is present requires the GraphQLName to search directly for the `@` rune.

Example: name `graphql:"name @skip(if: skipThis=true)"`

This issues allows the following to succeed:
```diff
type TeamsQuery struct {
	Organization struct {
		ID    githubv4.String
		Teams struct {
			Nodes []struct {
				ID          githubv4.String
				DatabaseID  githubv4.Int
				Slug        githubv4.String
				Name        githubv4.String
				Description githubv4.String
				Privacy     githubv4.String
				Members     struct {
					Nodes []struct {
						Login githubv4.String
					}
+				} `graphql:"members @skip(if: $summaryOnly)"`
				Repositories struct {
					Nodes []struct {
						Name githubv4.String
					}
+				} `graphql:"repositories @skip(if: $summaryOnly)"`
			}
			PageInfo PageInfo
		} `graphql:"teams(first:$first, after:$cursor, rootTeamsOnly:$rootTeamsOnly)"`
	} `graphql:"organization(login:$login)"`
}
```