### PR TITLE
ident: fix a typo in the comments

### DIFF
--- a/ident/ident.go
+++ b/ident/ident.go
@@ -118,7 +118,7 @@ func ParseScreamingSnakeCase(name string) Name {
 // Name is an identifier name, broken up into individual words.
 type Name []string
 
-// ToMixedCaps expresses identifer name in MixedCaps naming convention.
+// ToMixedCaps expresses identifier name in MixedCaps naming convention.
 //
 // E.g., "ClientMutationID".
 func (n Name) ToMixedCaps() string {
@@ -141,7 +141,7 @@ func (n Name) ToMixedCaps() string {
 	return strings.Join(n, "")
 }
 
-// ToLowerCamelCase expresses identifer name in lowerCamelCase naming convention.
+// ToLowerCamelCase expresses identifier name in lowerCamelCase naming convention.
 //
 // E.g., "clientMutationId".
 func (n Name) ToLowerCamelCase() string {


### PR DESCRIPTION
This PR fixes a typo in the comments.