### PR TITLE
Update specification url

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -104,7 +104,7 @@ func (c *Client) do(ctx context.Context, op operationType, v any, variables map[
 // errors represents the "errors" array in a response from a GraphQL server.
 // If returned via error interface, the slice is expected to contain at least 1 element.
 //
-// Specification: https://facebook.github.io/graphql/#sec-Errors.
+// Specification: https://spec.graphql.org/October2021/#sec-Errors.
 type errors []struct {
 	Message   string
 	Locations []struct {

--- a/query.go
+++ b/query.go
@@ -46,7 +46,7 @@ func queryArguments(variables map[string]any) string {
 		writeArgumentType(&buf, reflect.TypeOf(variables[k]), true)
 		// Don't insert a comma here.
 		// Commas in GraphQL are insignificant, and we want minified output.
-		// See https://facebook.github.io/graphql/October2016/#sec-Insignificant-Commas.
+		// See https://spec.graphql.org/October2021/#sec-Insignificant-Commas.
 	}
 	return buf.String()
 }


### PR DESCRIPTION
This PR changes the spec URL in the comments.

The old link https://facebook.github.io/graphql redirects to https://spec.graphql.org/