### PR TITLE
Properly split words with numbers

### DIFF
--- a/ident/ident.go
+++ b/ident/ident.go
@@ -23,6 +23,12 @@ func ParseMixedCaps(name string) Name {
 		eow := false // Whether we hit the end of a word.
 		if i+1 == len(runes) {
 			eow = true
+		} else if unicode.IsNumber(runes[i]) && unicode.IsUpper(runes[i+1]) {
+			// number -> Upper.
+			eow = true
+		} else if unicode.IsLower(runes[i]) && unicode.IsNumber(runes[i+1]) {
+			// lower -> number.
+			eow = true
 		} else if unicode.IsLower(runes[i]) && unicode.IsUpper(runes[i+1]) {
 			// lower -> Upper.
 			eow = true

--- a/ident/ident_test.go
+++ b/ident/ident_test.go
@@ -42,6 +42,9 @@ func TestParseMixedCaps(t *testing.T) {
 		{in: "HTTPSSQL", want: ident.Name{"HTTPS", "SQL"}},
 		{in: "UserIDs", want: ident.Name{"User", "IDs"}},
 		{in: "TeamIDsSorted", want: ident.Name{"Team", "IDs", "Sorted"}},
+		{in: "AnS3Variable", want: ident.Name{"An", "S3", "Variable"}},
+		{in: "Have86IDs", want: ident.Name{"Have", "86", "IDs"}},
+		{in: "95thPercentile", want: ident.Name{"95th", "Percentile"}},
 	}
 	for _, tc := range tests {
 		got := ident.ParseMixedCaps(tc.in)


### PR DESCRIPTION
If a field name has numbers then some new rules need to be added. I ran into a case where `FdrS3FileSizeMax` split the words into {"Fdr", "S3File", "Size", "Max"} which results in a subsequent call to `ToMixedCaps()` to return `FdrS3fileSizeMax` (notice the small 'f' after 'S3').