### PR TITLE
Add 'ANSI' as an allowable initialism

### DIFF
--- a/ident/ident.go
+++ b/ident/ident.go
@@ -181,6 +181,7 @@ func isTwoInitialisms(word string) (string, string, bool) {
 // For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
 var initialisms = map[string]struct{}{
 	"ACL":   {},
+	"ANSI":  {},
 	"API":   {},
 	"ASCII": {},
 	"CPU":   {},


### PR DESCRIPTION
I am working with code that refers to https://en.wikipedia.org/wiki/ANSI_escape_code and thus using keeping the capitalization of ANSI is useful.